### PR TITLE
[ADD] build-ubi-8: linux/s390x, linux/ppc64le

### DIFF
--- a/.github/workflows/build-ubi8.yml
+++ b/.github/workflows/build-ubi8.yml
@@ -21,7 +21,7 @@ on:
       - v*
   
 env:
-  BUILD_PLATFORMS: "linux/amd64,linux/arm64"
+  BUILD_PLATFORMS: "linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
   GO_VERSION: '1.15'
   KIND_VERSION: 'v0.11.0' 
 

--- a/.github/workflows/periodic-image-check.yml
+++ b/.github/workflows/periodic-image-check.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_PLATFORMS: "linux/amd64,linux/arm64"
+  BUILD_PLATFORMS: "linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
   
 jobs:
   setup:


### PR DESCRIPTION
* Adds new target platforms for image builds and base-image checks: linux/s390x, linux/ppc64le