### PR TITLE
[FIX] CI Containerfile: Update for OCP default SCC

### DIFF
--- a/.ci/Containerfile
+++ b/.ci/Containerfile
@@ -1,11 +1,10 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 ARG TARGETOS
 ARG TARGETARCH
-ARG ARCHIVE_PATH
 ARG BINARY
-
 WORKDIR /
 COPY ${BINARY}-${TARGETOS}-${TARGETARCH} /usr/local/bin/${BINARY}
+RUN chgrp -R 0 /usr/local/bin && chmod -R 775 /usr/local/bin/${BINARY}
 EXPOSE 8080
 USER 65532:65532
 ENTRYPOINT ["/usr/local/bin/kube-rbac-proxy"]


### PR DESCRIPTION
* Fixes permissions for anyuid, unix root group execution for upstream ENTRYPOINT of kube-rbac-proxy.
* Maintains upstream user:group for local testing as NONROOT default " 65532:65532" can override for testing with Openshfit "65532:0"