### PR TITLE
Fixes workflow tag triggers, go-version

### DIFF
--- a/.github/workflows/build-ubi8.yml
+++ b/.github/workflows/build-ubi8.yml
@@ -42,21 +42,21 @@ jobs:
             echo "::set-output name=image_repository_name::${IMAGE_REPOSITORY##*/}"
             echo "::set-output name=image_registry::${IMAGE_REPOSITORY%/*}"
           fi    
-      - name: Setting Go Variables 
-        id: set-go-variables
-        run: |
-          echo "::set-output name=go_version::$(yq eval '.env.go-version' .github/workflows/build.yml)"
       - name: Build Go Cache Paths
         id: go-cache-paths
         run: |
           echo "::set-output name=go-build::$(go env GOCACHE)"
           echo "::set-output name=go-mod::$(go env GOMODCACHE)"         
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Setting Go Variables
+        id: set-go-variables
+        run: |
+          echo "::set-output name=go_version::$(yq eval '.env.go-version' .github/workflows/build.yml)"
       - name: Set up Go 1.x
         uses: actions/setup-go@v1
         with:
           go-version: ${{ steps.set-go-variables.outputs.go_version }}
-      - name: Check out code
-        uses: actions/checkout@v2
       - name: Set VERSION Variable tracking from upstream
         id: set-version
         run: echo "::set-output name=version::$(cat VERSION)"

--- a/.github/workflows/build-ubi8.yml
+++ b/.github/workflows/build-ubi8.yml
@@ -4,26 +4,20 @@ on:
   workflow_call:
     secrets:
       REGISTRY_USERNAME:
-        description: 'Username for Registry'
+        description: "Username for Registry"
         required: true
       REGISTRY_PASSWORD:
-        description: 'Password for Registry'
+        description: "Password for Registry"
         required: true
       IMAGE_REPOSITORY:
-        description: 'Registry image e.g. quay.io/redhat-cop/$repoisitory-name'
+        description: "Registry image e.g. quay.io/redhat-cop/$repoisitory-name"
         required: false
   push:
-    branches:
-      - master
-      - main
-
     tags:        
       - v*
   
 env:
   BUILD_PLATFORMS: "linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
-  GO_VERSION: '1.15'
-  KIND_VERSION: 'v0.11.0' 
 
 jobs:
    setup:
@@ -35,7 +29,8 @@ jobs:
         run: |
           echo "::set-output name=repository_name::$(basename $GITHUB_REPOSITORY)"
           # Create Distribution Matrix
-          echo "::set-output name=dist_matrix::$(echo -n "${{ env.BUILD_PLATFORMS }}" | jq -csR '. | split(",")')"         
+          echo "::set-output name=dist_matrix::$(echo -n "${{ env.BUILD_PLATFORMS }}" | jq -csR '. | split(",")')"
+
       - name: Setting Image Variables
         id: set-variables-image
         run: |
@@ -47,6 +42,10 @@ jobs:
             echo "::set-output name=image_repository_name::${IMAGE_REPOSITORY##*/}"
             echo "::set-output name=image_registry::${IMAGE_REPOSITORY%/*}"
           fi    
+      - name: Setting Go Variables 
+        id: set-go-variables
+        run: |
+          echo "::set-output name=go_version::$(yq eval '.env.go-version' .github/workflows/build.yml)"
       - name: Build Go Cache Paths
         id: go-cache-paths
         run: |
@@ -55,7 +54,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v1
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ steps.set-go-variables.outputs.go_version }}
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set VERSION Variable tracking from upstream
@@ -79,6 +78,7 @@ jobs:
       image_registry: ${{ steps.set-variables-image.outputs.image_registry }}
       go_build: ${{ steps.go-cache-paths.outputs.go-build }}
       go_mod: ${{ steps.go-cache-paths.outputs.go-mod }}
+      go_version: ${{ steps.set-go-variables.outputs.go_version }}
       tag_event: ${{ steps.set-variables-image.outputs.tag_event }}
       dist_matrix: ${{ steps.set-variables.outputs.dist_matrix }}
       version: ${{ steps.set-version.outputs.version}}
@@ -95,11 +95,12 @@ jobs:
       REPOSITORY_NAME: ${{ needs.setup.outputs.repository_name }}
       VERSION: ${{ needs.setup.outputs.version }}
       ARCHIVE: ${{ needs.setup.outputs.repository_name }}-${{ github.run_id }}-${{ github.run_number }}
+      GO_VERSION: ${{ needs.setup.outputs.go_version }}
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v1
         with:
-          go-version: ${{ env.go-version }}
+          go-version: ${{ env.GO_VERSION }}
       - name: Check out code
         uses: actions/checkout@v2
       - name: Go Build Cache
@@ -123,7 +124,7 @@ jobs:
           GOOS: ${{ steps.setup-build-step.outputs.platform_os }}
           GOARCH: ${{ steps.setup-build-step.outputs.platform_arch }}
         run: make build      
-      - name: Archive go-platform binairies
+      - name: Archive go-platform binaries
         env:
           GOOS: ${{ steps.setup-build-step.outputs.platform_os }}
           GOARCH: ${{ steps.setup-build-step.outputs.platform_arch }}


### PR DESCRIPTION
* [FIX] Workflow only runs on "push" events to version tags "v.*" to resolve image overwrites.
* [FIX] Workflow reads the Go Version from upstream build.yml to ensure compatibility.
